### PR TITLE
Fix printing issue for firefox

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -124,13 +124,13 @@ export default {
         $("#print-emission-rates").html("");
         var clonedMap = $("#subregionMap > svg")
           .clone()
-          .css({ verticalAlign: "top", width: "166px", height: "100px" });
+          .css({ verticalAlign: "top", width: "300px", height: "200px" });
         $("#print-map").append(clonedMap);
         $("#print-fuel-mix").append($("#fuelMixContainer").clone());
         $("#print-fuel-mix svg").css({
           marginTop: "0",
-          height: "480px",
-          width: "347px"
+          height: "100%",
+          width: "100%"
         });
         $("#print-emission-rates").append("<h3>Emission Rates</h3>");
         $("#print-emission-rates").append($("#emRatesDescription").clone());
@@ -151,6 +151,7 @@ export default {
         );
         $("#printReportMain").hide();
         self.showReport = true;
+        $("#printReport").show();
       } else {
         $("#print-main-map").html("");
         $("#print-main-fuel-mix").html("");
@@ -177,8 +178,10 @@ export default {
         $("#print-main-emission-rates > #nationalEmissionRateGraph > svg").css({
           display: "inline-block"
         });
-        $("#printReport").hide();
         self.showMainReport = true;
+        $("#printReportMain").show();
+        $("#printReport").hide();
+
       }
     });
     window.addEventListener("afterprint", function(event) {

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -149,8 +149,8 @@ export default {
             .clone()
             .css({ display: "inline-block", height: "443px" })
         );
-        $("#printReportMain").hide();
         self.showReport = true;
+        $("#printReportMain").hide();
         $("#printReport").show();
       } else {
         $("#print-main-map").html("");
@@ -187,6 +187,8 @@ export default {
     window.addEventListener("afterprint", function(event) {
       self.showReport = false;
       self.showMainReport = false;
+      $("#printReport").hide();
+      $("#printReportMain").hide();
     });
 
     if ($(window).width() < 1025) {


### PR DESCRIPTION
For some reason, vue does not update the components with v-show before Firefox creates the print preview, even though we update the value to show the component in a callback function before the print preview appears. 

The solution was to modify the display property before and after the print. 

closes #57 