### PR TITLE
reset previous options when select egrid-subregions

### DIFF
--- a/app/TESTING.md
+++ b/app/TESTING.md
@@ -61,7 +61,7 @@ A general testing guide for manual review of changes to the Power Profiler.
                 * Check to see if the value for a selected subregion shows up above the bar for that region and the region is bolded in the x*axis
     * Maps
         * Test all links in description
-        * Emisssion Rate Map
+        * Emission Rate Map
             * Test tooltips in English and Spanish
         * Renewable/Non*renewable Map
             * Test tooltips in English and Spanish
@@ -106,7 +106,7 @@ A general testing guide for manual review of changes to the Power Profiler.
             □ Opens an input box for entering square footage
             □ The first paragraph and all charts change when entering square footage
         * Test that the switch to residential button hides the commercial customer input and changes all text and charts to the previous text for the residential inputs
-    * Test that all the charts (Guage chart, CO2, SO2, and NOx) charts are present and change when input changes
+    * Test that all the charts (Gauge chart, CO2, SO2, and NOx) charts are present and change when input changes
 
 * Print report
     * Check that the print report feature works and shows all the information that is present on the screen at the time of clicking the button

--- a/app/src/components/SubregionSelection.vue
+++ b/app/src/components/SubregionSelection.vue
@@ -201,6 +201,11 @@ export default {
       this.selectedSubregion = allSubregions.data.filter(
         d => d.properties.name == subAcronym
       )[0];
+      if(subAcronym === "All") {  
+        this.$router.push({name: 'home'});   
+        this.$root.$emit("subregionSelected", subAcronym);
+        return;
+      }
       this.$root.$emit("subregionSelected", this.selectedSubregion);
     }
   },

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -27,6 +27,14 @@ var vm = new Vue({
 });
 
 vm.$on("subregionSelected", function(d) {
+  if (d === "All") {
+    $(".map").css({ fill: "" });
+    this.$children[0].$children[4].$children[0].selectedRegion = {};
+    this.$children[0].$children[4].selectedRegion = {};
+    this.$root.showMain = true;
+    this.$root.selectedSubregion = false;
+  }
+  else{
   selectedSubregion.update(d);
   this.$children[0].$children[4].$children[0].selectedRegion =
     selectedSubregion.data;
@@ -34,7 +42,7 @@ vm.$on("subregionSelected", function(d) {
   $(".map").css({ fill: "" });
   $("." + d.properties.name).css({ fill: "steelblue" });
   $("#regionSelectionDropdown").val(d.properties.name);
-  router.push(d.properties.name);
+  router.push(d.properties.name); }
 });
 
 if (typeof ga === "function") {


### PR DESCRIPTION
reset previous selection when selecting "eGRID subregions" from list.  Changes applied to two files: main.js and SubregionSelection.vue.  Preview page: https://test-power-profiler-fix-egrid-selection.app.cloud.gov/#/