### PR TITLE
Fix national annual electricity in monthly input

### DIFF
--- a/app/src/components/EmissionsCalculator.vue
+++ b/app/src/components/EmissionsCalculator.vue
@@ -848,6 +848,24 @@ export default {
         $("#residentialCustomersButton").hide();
       });
 
+      $("#calculateMonthlyAverageButton").click(function() {
+        self.commercialCustomerForm = false;
+        self.residentialMode = true;
+        self.userSelectionStore.setResidentialMode(true);
+        self.displayNationalAverage();
+        $("#customerText").show();
+        $("#residentialCustomersButton").hide();     
+      });
+
+      $("#calculateMonthlyActualButton").click(function() {
+        self.commercialCustomerForm = false;
+        self.residentialMode = true;
+        self.userSelectionStore.setResidentialMode(true);
+        self.displayNationalAverage();
+        $("#customerText").show();
+        $("#residentialCustomersButton").hide();        
+      });
+
       $("#annual-results-text").hide();
       $("#national-avg-annual-results-text").show();
       $("#result").show();

--- a/app/src/components/SideBar.vue
+++ b/app/src/components/SideBar.vue
@@ -93,7 +93,7 @@
           for="additionalInfo.powerProfilerExcelLink"
         >
           <a
-            href="https://www.epa.gov/sites/production/files/2020-11/power_profiler_zipcode_tool.xlsx"
+            href="https://www.epa.gov/system/files/other-files/2021-09/power_profiler_zipcode_tool_2019.xlsx"
             v-bind:aria-label="$t('ariaLabels.downloadsTool')"
             >{{ $t("additionalInfo.powerProfilerExcelLink") }}</a
           >
@@ -101,7 +101,7 @@
         </i18n>
         <p>
           <a
-            href="https://www.epa.gov/egrid/forms/egrid-and-power-profiler-notification"
+            href="https://lp.constantcontactpages.com/su/sG18AaT"
             target="_blank"
             v-bind:aria-label="$t('ariaLabels.opensNewWin')"
             >{{ $t("additionalInfo.mailingList") }}</a

--- a/app/src/helpers/Tooltip.js
+++ b/app/src/helpers/Tooltip.js
@@ -24,7 +24,6 @@ function addTooltip(className) {
       }
     },
     mousemove: function(e) {
-      // Check if element is a national bar (on the righthand side of the page)
       // Check if element is a national bar (on the right-hand-side of the page)
       const natBar = $(this).closest('.nationalBar');
 

--- a/app/src/helpers/const.js
+++ b/app/src/helpers/const.js
@@ -1,8 +1,8 @@
 export const constVal = {
-    carbonSequesteredByYear: 0.82,
-    carbonSequesteredByAcre: 146.27,
+    carbonSequesteredByYear: 0.84,
+    carbonSequesteredByAcre: 148.26,
     avgConsumptionSqft: 1.22, 
-    annualAverage: 11880,
+    nationalTotal: 11880,
     nationalAverage: 990
 };
 


### PR DESCRIPTION
Reset the national annual value when toggling between commercial customer input and monthly input.  Review cloud app, https://test-power-profiler-constant-changes.app.cloud.gov/#/