### PR TITLE
Patch to parse 2010-2016 data

### DIFF
--- a/prep/README.md
+++ b/prep/README.md
@@ -6,6 +6,7 @@
 - [Mapshaper command line tool](https://github.com/mbloch/mapshaper):
 ```bash
 npm install -g mapshaper@0.4.125
+pip install -f requirements.txt
 ```
 
 Power Profiler runs on two data files, `zip.csv` and `subregion.json`. The zip-subregion utility lookup data comes from the "Zip-subregion" tab of the Power Profiler Emissions Tool Excel file. This can be found on [the eGRID website](https://www.epa.gov/egrid). Follow these steps to update the `subregion.json` file (for a new year of eGRID data, for example):

--- a/prep/README.md
+++ b/prep/README.md
@@ -6,7 +6,7 @@
 - [Mapshaper command line tool](https://github.com/mbloch/mapshaper):
 ```bash
 npm install -g mapshaper@0.4.125
-pip install -f requirements.txt
+pip install -r requirements.txt
 ```
 
 Power Profiler runs on two data files, `zip.csv` and `subregion.json`. The zip-subregion utility lookup data comes from the "Zip-subregion" tab of the Power Profiler Emissions Tool Excel file. This can be found on [the eGRID website](https://www.epa.gov/egrid). Follow these steps to update the `subregion.json` file (for a new year of eGRID data, for example):

--- a/prep/add_egrid_data.py
+++ b/prep/add_egrid_data.py
@@ -111,15 +111,19 @@ renewables = {
 sn['SRNOXRTA'] = sn['SRNOXRTA'].round(3)
 sn['SRSO2RTA'] = sn['SRSO2RTA'].round(3)
 sn['SRCO2RTA'] = sn['SRCO2RTA'].round(3)
+sn['SRC2ERTA'] = sn['SRC2ERTA'].round(3)
 sn['SRNOXRTA_STR'] = sn['SRNOXRTA'].round(3).astype('str')
 sn['SRSO2RTA_STR'] = sn['SRSO2RTA'].round(3).astype('str')
 sn['SRCO2RTA_STR'] = sn['SRCO2RTA'].map('{:,.1f}'.format)
+sn['SRC2ERTA_STR'] = sn['SRC2ERTA'].map('{:,.1f}'.format)
 n['USNOXRTA'] = n['USNOXRTA'].round(3)
 n['USSO2RTA'] = n['USSO2RTA'].round(3)
 n['USCO2RTA'] = n['USCO2RTA'].round(3)
+n['USC2ERTA'] = n['USC2ERTA'].round(3)
 n['USNOXRTA_STR'] = n['USNOXRTA'].round(3).astype('str')
 n['USSO2RTA_STR'] = n['USSO2RTA'].round(3).astype('str')
 n['USCO2RTA_STR'] = n['USCO2RTA'].map('{:,.1f}'.format)
+n['USC2ERTA_STR'] = n['USC2ERTA'].map('{:,.1f}'.format)
 # Set up lists for checking whether subregion is in one of the interconnect power grids.
 alaska = ['AKGD','AKMS']
 hawaii = ['HIMS','HIOA']
@@ -197,6 +201,11 @@ for feature in data["features"]:
                     "co2EmissionRate": {
                         "value": row["SRCO2RTA"],
                         "display": row["SRCO2RTA_STR"],
+                        "units": "lb/MWh"
+                    },
+                    "co2eEmissionRate": {
+                        "value": row["SRC2ERTA"],
+                        "display": row["SRC2ERTA_STR"],
                         "units": "lb/MWh"
                     },
                     "noxEmissionRate": {
@@ -316,7 +325,12 @@ national = {
                 "units":"lb/MWh",
                 "display":n['USCO2RTA_STR'].values[0],
                 "value":n['USCO2RTA'].values[0]
-                }
+                },
+            "co2eEmissionRate":{
+                "units":"lb/MWh",
+                "display":n['USC2ERTA_STR'].values[0],
+                "value":n['USC2ERTA'].values[0]
+                },
         },
         "gridLoss": {
             "display": gl[gl['REGION'] == 'U.S.']['GGRSLOSS_STR'].values[0],

--- a/prep/add_egrid_data.py
+++ b/prep/add_egrid_data.py
@@ -210,6 +210,7 @@ for feature in data["features"]:
     # Add eGRID data values.
     for index, row in sn.iterrows():
         if "name" in feature["properties"]:
+            feature["properties"]["dataYear"] = data_year_num
             if feature["properties"]["name"] == row["SUBRGN"]:
                 feature["properties"]["type"] = "subregion"
                 feature["properties"]["fullName"] = row["SRNAME"]
@@ -309,6 +310,7 @@ national = {
     "type":"Feature",
     "geometry":{},
     "properties":{
+        "dataYear": data_year_num,
         "name":"National",
         "type":"national",
         "fullName":"National",

--- a/prep/add_egrid_data.py
+++ b/prep/add_egrid_data.py
@@ -183,6 +183,8 @@ for feature in data["features"]:
         feature["properties"]["name"] = feature["properties"].pop("ZipSubregi")
     if "zips_for_G" in feature["properties"]:
         feature["properties"]["name"] = feature["properties"].pop("zips_for_G")
+    if "Subregions" in feature["properties"]:
+        feature["properties"]["name"] = feature["properties"].pop("Subregions")
     if("STATE" in feature["properties"]):
         feature["properties"]["type"] = "state"
     # Add eGRID data values.

--- a/prep/requirements.txt
+++ b/prep/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+xlrd
+openpyxl


### PR DESCRIPTION
Older EPA eGRID shapefile data has a slightly different format. These changes allow the parsing script to work with older data formats.

Example usage:

```
% python add_egrid_data.py --data_year 2010  -k 4 data/excel/eGRID2010_Data.xls data/shape/2014/eGRID2014_subregions.shp
% python add_egrid_data.py --data_year 2012  -k 4 data/excel/eGRID2012_Data.xlsx data/shape/2014/eGRID2014_subregions.shp
% python add_egrid_data.py --data_year 2014  -k 1 data/excel/eGRID2014_Data_v2.xlsx data/shape/2014/eGRID2014_subregions.shp
% python add_egrid_data.py --data_year 2016  -k 1 data/excel/egrid2016_data.xlsx data/shape/2016/eGRID2016\ Subregions.shp
```

Note that the addition of the `co2eEmissionRate` property into the resulting subregion.json file is not consumed by your JS code currently, but I needed it for my project. AFAIK it will be just be ignored by your code and should add minimal extra size to the file.